### PR TITLE
Fix image buffer management in OCR

### DIFF
--- a/backend/open_webui/retrieval/loaders/ocrprocessor.py
+++ b/backend/open_webui/retrieval/loaders/ocrprocessor.py
@@ -433,10 +433,10 @@ def ocr_image(image_path, ocr_reader, ocr_engine="easyocr"):
             img = img.convert("RGB")
             max_size = (2000, 2000)
             img.thumbnail(max_size, Image.LANCZOS)
-            buffer = BytesIO()
             # Save image as PNG to standardize the OCR input while retaining original format info
-            img.save(buffer, format="PNG")
-            img_bytes = buffer.getvalue()
+            with BytesIO() as buffer:
+                img.save(buffer, format="PNG")
+                img_bytes = buffer.getvalue()
             preprocessed_img = preprocess_image_cv2(img_bytes)
             if preprocessed_img is None:
                 return []


### PR DESCRIPTION
## Summary
- improve OCR image conversion logic by using a context manager

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'test.util')*

------
https://chatgpt.com/codex/tasks/task_e_68525f8f1418832faa0008c9b21194ec