### PR TITLE
Improve Milvus performance and organisation

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -1789,6 +1789,8 @@ MILVUS_METRIC_TYPE = os.environ.get("MILVUS_METRIC_TYPE", "COSINE")
 MILVUS_HNSW_M = int(os.environ.get("MILVUS_HNSW_M", "16"))
 MILVUS_HNSW_EFCONSTRUCTION = int(os.environ.get("MILVUS_HNSW_EFCONSTRUCTION", "100"))
 MILVUS_IVF_FLAT_NLIST = int(os.environ.get("MILVUS_IVF_FLAT_NLIST", "128"))
+MILVUS_HNSW_SEARCH_EF = int(os.environ.get("MILVUS_HNSW_SEARCH_EF", "50"))
+MILVUS_IVF_FLAT_NPROBE = int(os.environ.get("MILVUS_IVF_FLAT_NPROBE", "10"))
 
 # Qdrant
 QDRANT_URI = os.environ.get("QDRANT_URI", None)


### PR DESCRIPTION
## Summary
- add search tuning parameters for Milvus in config
- organize Milvus collections into `knowledge` and `files` prefixes
- use optimized search parameters and lazy load collections

## Testing
- `npm run lint:backend` *(fails: `pylint` not found)*
- `npm run test:frontend` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855fead6efc832fa1386bc766c75d59