### PR TITLE
Add OAuth silent login

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,10 @@ If you are running Open WebUI in an offline environment, you can set the `HF_HUB
 export HF_HUB_OFFLINE=1
 ```
 
+### OAuth Silent Login
+
+Set `OAUTH_SILENT_LOGIN=true` to automatically attempt a silent OAuth login. When enabled, the `/auth` page redirects to `/oauth/oidc/login?silent=true` if no user session is present.
+
 ## What's Next? 🌟
 
 Discover upcoming features on our roadmap in the [Open WebUI Documentation](https://docs.openwebui.com/roadmap/).

--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -529,6 +529,12 @@ OAUTH_UPDATE_PICTURE_ON_LOGIN = PersistentConfig(
     os.environ.get("OAUTH_UPDATE_PICTURE_ON_LOGIN", "False").lower() == "true",
 )
 
+OAUTH_SILENT_LOGIN = PersistentConfig(
+    "OAUTH_SILENT_LOGIN",
+    "oauth.silent_login",
+    os.environ.get("OAUTH_SILENT_LOGIN", "False").lower() == "true",
+)
+
 
 def load_oauth_providers():
     OAUTH_PROVIDERS.clear()

--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -339,6 +339,7 @@ from open_webui.config import (
     OAUTH_USERNAME_CLAIM,
     OAUTH_ALLOWED_ROLES,
     OAUTH_ADMIN_ROLES,
+    OAUTH_SILENT_LOGIN,
     # WebUI (LDAP)
     ENABLE_LDAP,
     LDAP_SERVER_LABEL,
@@ -1511,7 +1512,8 @@ async def get_app_config(request: Request):
             "providers": {
                 name: config.get("name", name)
                 for name, config in OAUTH_PROVIDERS.items()
-            }
+            },
+            "silent_login": OAUTH_SILENT_LOGIN.value,
         },
         "features": {
             "auth": WEBUI_AUTH,
@@ -1682,8 +1684,8 @@ if len(OAUTH_PROVIDERS) > 0:
 
 
 @app.get("/oauth/{provider}/login")
-async def oauth_login(provider: str, request: Request):
-    return await oauth_manager.handle_login(request, provider)
+async def oauth_login(provider: str, request: Request, silent: bool = False):
+    return await oauth_manager.handle_login(request, provider, silent)
 
 
 # OAuth login logic is as follows:

--- a/cypress/e2e/silent-login.cy.ts
+++ b/cypress/e2e/silent-login.cy.ts
@@ -1,0 +1,22 @@
+// eslint-disable-next-line @typescript-eslint/triple-slash-reference
+/// <reference path="../support/index.d.ts" />
+import { adminUser } from '../support/e2e';
+
+describe('OAuth silent login', () => {
+    before(() => {
+        cy.registerAdmin();
+    });
+
+    it('redirects to oauth login when silent login enabled', () => {
+        cy.loginAdmin();
+        cy.request('/api/v1/configs/export').then((res) => {
+            const cfg = res.body;
+            cfg.oauth = cfg.oauth || {};
+            cfg.oauth.silent_login = true;
+            cy.request('POST', '/api/v1/configs/import', { config: cfg });
+        });
+        cy.intercept('GET', '/oauth/oidc/login*').as('silent');
+        cy.visit('/auth');
+        cy.wait('@silent').its('request.url').should('include', 'silent=true');
+    });
+});

--- a/src/lib/stores/index.ts
+++ b/src/lib/stores/index.ts
@@ -217,11 +217,12 @@ type Config = {
 		enable_autocomplete_generation: boolean;
 		enable_direct_connections: boolean;
 	};
-	oauth: {
-		providers: {
-			[key: string]: string;
-		};
-	};
+        oauth: {
+                providers: {
+                        [key: string]: string;
+                };
+                silent_login?: boolean;
+        };
 	ui?: {
 		pending_user_overlay_title?: string;
 		pending_user_overlay_description?: string;

--- a/src/routes/auth/+page.svelte
+++ b/src/routes/auth/+page.svelte
@@ -137,15 +137,24 @@
 		}
 	}
 
-	onMount(async () => {
-		if ($user !== undefined) {
-			const redirectPath = querystringValue('redirect') || '/';
-			goto(redirectPath);
-		}
-		await checkOauthCallback();
+        onMount(async () => {
+                if ($user !== undefined) {
+                        const redirectPath = querystringValue('redirect') || '/';
+                        goto(redirectPath);
+                }
+                await checkOauthCallback();
 
-		loaded = true;
-		setLogoImage();
+                if (
+                        $config?.oauth?.silent_login === true &&
+                        !$user &&
+                        $config?.oauth?.providers?.oidc
+                ) {
+                        window.location.href = `${WEBUI_BASE_URL}/oauth/oidc/login?silent=true`;
+                        return;
+                }
+
+                loaded = true;
+                setLogoImage();
 
 		if (($config?.features.auth_trusted_header ?? false) || $config?.features.auth === false) {
 			await signInHandler();


### PR DESCRIPTION
## Summary
- add `OAUTH_SILENT_LOGIN` configuration option
- pass optional `silent` flag to OAuth login
- auto redirect to silent login on frontend
- document silent login flag
- test silent login flow with Cypress

## Testing
- `npm run lint:frontend` *(fails: ESLint couldn't find configuration)*
- `npm run lint:backend` *(fails: pylint not found)*

------
https://chatgpt.com/codex/tasks/task_e_686546cd36d8832fb910a4424cf67a14